### PR TITLE
client/auth: fix special characters accepted in UI

### DIFF
--- a/gwcli/client.py
+++ b/gwcli/client.py
@@ -228,7 +228,7 @@ class Client(UINode):
                      hostname or iqn
         password ... the password must be between 12-16 chars in length
                      containing alphanumeric characters plus the following
-                     special characters !,&,_
+                     special characters @,_,-
 
         """
 

--- a/gwcli/utils.py
+++ b/gwcli/utils.py
@@ -334,7 +334,7 @@ def valid_credentials(credentials_str, auth_type='chap'):
         # password is 12-16 chars long containing any alphanumeric
         # or !,_,& symbol
         usr_regex = re.compile("^[\w\\.\:]+")
-        pw_regex = re.compile("^[\w\!\&\_]{12,16}$")
+        pw_regex = re.compile("^[\w\@\-\_]{12,16}$")
         if not usr_regex.search(user_name) or not pw_regex.search(password):
             return False
 


### PR DESCRIPTION
rtslib silently strips some special characters, so this update restricts
the chars in the password to characters known to work, and updates the
help text to reflect the chars that can be used in a password