### PR TITLE
Patches to tidy up host group management

### DIFF
--- a/gwcli/client.py
+++ b/gwcli/client.py
@@ -175,7 +175,7 @@ class Client(UINode):
                  CHAP authentication for the client (1-WAY) and change the 
                  rbd images masked to a specific client.
                   
-                 Lun masking automatically associates a specific LUN id to the
+                 LUN masking automatically associates a specific LUN id to the
                  for an rbd image, simplifying the workflow. The lun id's 
                  assigned can be seen by running the 'info' command. This will 
                  show all the clients details that are stored within the 
@@ -313,11 +313,12 @@ class Client(UINode):
     def ui_command_disk(self, action='add', disk=None, size=None):
         """
         Disks can be added or removed from the client one at a time using
-        the 'disk' sub-command. Note that the disk MUST already be defined
-        within the configuration
+        the 'disk' sub-command. Note that if the disk does not currently exist
+        in the configuration, the cli will attempt to create it for you.
 
         e.g.
-        disk add|remove <disk_name>
+        disk add <disk_name> <size>
+        disk remove <disk_name>
 
         Adding a disk will result in the disk occupying the client's next
         available lun id. Once allocated removing a LUN will not change the

--- a/gwcli/node.py
+++ b/gwcli/node.py
@@ -69,7 +69,10 @@ class UINode(UIGroup):
 
         display_text = ''
 
-        field_list = self.display_attributes if self.display_attributes else []
+        if not self.display_attributes:
+            return "'info' not available for this item"
+
+        field_list = self.display_attributes
         max_field_size = len(max(field_list, key=len))
         for k in field_list:
             attr_label = k.replace('_', ' ').title()

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -108,8 +108,10 @@ class Disks(UIGroup):
                           "be replicated".format(pool))
         return False
 
-    def create_disk(self, pool=None, image=None, size=None, count=None,
+    def create_disk(self, pool=None, image=None, size=None, count=1,
                     parent=None):
+
+        rc = 0
 
         if not parent:
             parent = self
@@ -169,9 +171,11 @@ class Disks(UIGroup):
                 else:
                     raise GatewayAPIError("Unable to retrieve disk details "
                                           "for '{}' from the API".format(disk_key))
-
         else:
             self.logger.error("Failed : {}".format(api.response.json()['message']))
+            rc = 8
+
+        return rc
 
     def find_hosts(self):
         hosts = []

--- a/gwcli/utils.py
+++ b/gwcli/utils.py
@@ -246,8 +246,9 @@ def valid_disk(**kwargs):
             new_disks = set(['{}{}'.format(disk_key, ctr)
                              for ctr in range(1, limit)])
 
-        if new_disks.issubset(set(config['disks'])):
-            return "rbd image(s) of that name/prefix are already defined"
+        if any(new_disk in config['disks'] for new_disk in new_disks):
+            return ("at least one rbd image(s) with that name/prefix is "
+                    "already defined")
 
         gateways_defined = len([key for key in config['gateways']
                                if isinstance(config['gateways'][key],

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -33,8 +33,6 @@ from gwcli.utils import (this_host, APIRequest, valid_gateway,
 
 from gwcli.client import Client
 
-__author__ = "pcuzner@redhat.com"
-
 app = Flask(__name__)
 
 
@@ -1116,7 +1114,7 @@ def hostgroup(group_name):
         if group_name in config.config['groups']:
             host_group = config.config['groups'].get(group_name)
             current_members = host_group.get('members')
-            current_disks = host_group.get('disks')
+            current_disks = host_group.get('disks').keys()
         else:
             current_members = []
             current_disks = []

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -553,19 +553,20 @@ def disk(image_id):
             return jsonify(message="rbd image {} not "
                                    "found".format(image_id)), 404
 
-    elif request.method == 'PUT':
-        # This is a create/resize operation, so first confirm the gateways
-        # are in place (we need gateways to perform the lun masking tasks
-        gateways = [key for key in config.config['gateways']
-                    if isinstance(config.config['gateways'][key], dict)]
-        logger.debug("All gateways: {}".format(gateways))
+    # This is a create/resize operation, so first confirm the gateways
+    # are in place (we need gateways to perform the lun masking tasks
+    gateways = [key for key in config.config['gateways']
+                if isinstance(config.config['gateways'][key], dict)]
+    logger.debug("All gateways: {}".format(gateways))
 
-        # Any disk operation needs at least 2 gateways to be present
-        if len(gateways) < 2:
-            msg = "at least 2 gateways must exist before disk operations " \
-                  "are permitted"
-            logger.warning("disk create request failed: {}".format(msg))
-            return jsonify(message=msg), 400
+    # Any disk operation needs at least 2 gateways to be present
+    if len(gateways) < 2:
+        msg = "at least 2 gateways must exist before disk operations " \
+              "are permitted"
+        logger.warning("disk create request failed: {}".format(msg))
+        return jsonify(message=msg), 400
+
+    if request.method == 'PUT':
 
         # at this point we have a disk request, and the gateways are available
         # for the LUN masking operations


### PR DESCRIPTION
addresses the sequence issue when defining a group (disk first then host or vice-versa)

NB. Requires the changes provided by the ceph-iscsi-config group-fix branch