### PR TITLE
Fix ui delete

### DIFF
--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -251,12 +251,24 @@ class Disks(UIGroup):
         destructive action that could lead to data loss, so please ensure
         the rbd image name is correct!
 
-        > delete <rbd_image_name>
+        > delete <disk_name>
+        e.g.
+        > delete rbd.disk_1
+
+        "disk_name" refers to the name of the disk as shown in the UI, for
+        example rbd.disk_1.
 
         Also note that the delete process is a synchronous task, so the larger
         the rbd image is, the longer the delete will take to run.
 
         """
+
+        # Perform a quick 'sniff' test on the request
+        if image_id not in [disk.image_id for disk in self.children]:
+            self.logger.error("Disk '{}' is not defined to the "
+                              "configuration".format(image_id))
+            return
+
         self.logger.debug("CMD: /disks delete {}".format(image_id))
 
         self.logger.debug("Starting delete for rbd {}".format(image_id))

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -10,6 +10,7 @@ import OpenSSL
 import threading
 import time
 import inspect
+import re
 
 from functools import wraps
 from rpm import labelCompare
@@ -540,6 +541,12 @@ def disk(image_id):
     Examples:
     curl --insecure --user admin:admin -d mode=create -d size=1g -d pool=rbd -d count=5 -X PUT https://192.168.122.69:5001/api/all_disk/rbd.new2_
     """
+
+    disk_regex = re.compile("^\w+(\.)(\w+)")
+    if not disk_regex.search(image_id):
+        logger.debug("disk request rejected due to invalid image name")
+        return jsonify(message="image id format is invalid - must be "
+                               "pool.image_name"), 400
 
     local_gw = this_host()
     logger.debug("this host is {}".format(local_gw))

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -628,6 +628,7 @@ def disk(image_id):
         api_vars = {'purge_host': local_gw}
 
         # process other gateways first
+        gateways.remove(local_gw)
         gateways.append(local_gw)
 
         resp_text, resp_code = call_api(gateways, '_disk',


### PR DESCRIPTION
Address the disk delete issues when the image_id supplied is invalid. The cli now ensures the disk is actually valid prior to issuing the api call, and the api itself validates that the image_id format matches a pool.image pattern