### PR TITLE
add cmd_time_out option to /disks create command

### DIFF
--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -58,7 +58,8 @@ class Disks(UIGroup):
         for child in children:
             self.remove_child(child)
 
-    def ui_command_create(self, pool=None, image=None, size=None, count=1):
+    def ui_command_create(self, pool=None, image=None, size=None, count=1,
+                          cmd_time_out=None):
         """
         Create a LUN and assign to the gateway(s).
 
@@ -83,6 +84,8 @@ class Disks(UIGroup):
                 create rbd.test 1g count=5
                 -> create 5 LUNs called test1..test5 each of 1GB in size
                    from the rbd pool
+        cmd_time_out ： Optional, integer(defaults to 30, i.e. TCMU_TIME_OUT),
+                value of TCMU command timeout.
 
         Notes.
         1) size does not support decimal representations
@@ -128,12 +131,14 @@ class Disks(UIGroup):
                 return
 
         self.logger.debug("CMD: /disks/ create pool={} "
-                          "image={} size={} count={}".format(pool,
+                    "image={} size={} count={} cmd_time_out={}".format(pool,
                                                              image,
                                                              size,
-                                                             count))
+                                                             count,
+                                                             cmd_time_out))
 
-        self.create_disk(pool=pool, image=image, size=size, count=count)
+        self.create_disk(pool=pool, image=image, size=size,
+                         count=count, cmd_time_out=cmd_time_out)
 
     def _valid_pool(self, pool=None):
         """
@@ -161,7 +166,7 @@ class Disks(UIGroup):
         return False
 
     def create_disk(self, pool=None, image=None, size=None, count=1,
-                    parent=None):
+                    cmd_time_out=None, parent=None):
 
         rc = 0
 
@@ -184,7 +189,8 @@ class Disks(UIGroup):
                                                               disk_key)
 
         api_vars = {'pool': pool, 'size': size.upper(), 'owner': local_gw,
-                    'count': count, 'mode': 'create'}
+                    'count': count, 'mode': 'create',
+                    'cmd_time_out': cmd_time_out}
 
         self.logger.debug("Issuing disk create request")
 

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -597,6 +597,7 @@ def disk(image_id):
         size = request.form.get('size')
         mode = request.form.get('mode')
         count = request.form.get('count', '1')
+        cmd_time_out = request.form.get('cmd_time_out', None)
 
         pool, image_name = image_id.split('.')
 
@@ -615,7 +616,7 @@ def disk(image_id):
                                                                      sfx)
 
             api_vars = {'pool': pool, 'size': size, 'owner': local_gw,
-                        'mode': mode}
+                        'mode': mode, 'cmd_time_out': cmd_time_out}
 
             resp_text, resp_code = call_api(gateways, '_disk',
                                             image_name,
@@ -686,7 +687,8 @@ def _disk(image_id):
                       str(request.form['pool']),
                       image_name,
                       str(request.form['size']),
-                      str(request.form['owner']))
+                      str(request.form['owner']),
+                      request.form.get('cmd_time_out', None))
             if lun.error:
                 logger.error("Unable to create a LUN instance"
                              " : {}".format(lun.error_msg))
@@ -729,7 +731,7 @@ def _disk(image_id):
         else:
 
             # this is an invalid request
-            return jsonify(message="Invalid Request - need to provide"
+            return jsonify(message="Invalid Request - need to provide "
                                    "pool, size and owner"), 400
 
     else:


### PR DESCRIPTION
Provide a cmd_time_out option to make configfs attribute
cmd_time_out optionally configrable when adding a disk node
to the configuration.

Signed-off-by: Zhang Zhuoyu <zhangzhuoyu@cmss.chinamobile.com>