### PR TITLE
Reduce startup time

### DIFF
--- a/gwcli.py
+++ b/gwcli.py
@@ -62,6 +62,9 @@ def get_options():
     parser.add_argument('-d', '--debug', action='store_true',
                         default=False,
                         help='run with additional debug')
+    parser.add_argument('-t', '--threads', type=int,
+                        default=8,
+                        help='threads used for rbd scanning (default is 8)')
     parser.add_argument('-v', '--version', action='version',
                         version='%(prog)s - {}'.format(__version__))
     parser.add_argument('cli_command', type=str, nargs=argparse.REMAINDER)
@@ -90,7 +93,8 @@ def main():
 
     shell = GatewayCLI('~/.gwcli')
 
-    root_node = ISCSIRoot(shell)
+    root_node = ISCSIRoot(shell,
+                          scan_threads=options.threads)
 
     root_node.interactive = False if options.cli_command else True
     settings.config.interactive = False if options.cli_command else True

--- a/gwcli/gateway.py
+++ b/gwcli/gateway.py
@@ -27,12 +27,13 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 class ISCSIRoot(UIRoot):
 
-    def __init__(self, shell, endpoint=None):
+    def __init__(self, shell, scan_threads=1, endpoint=None):
         UIRoot.__init__(self, shell)
 
         self.error = False
         self.error_msg = ''
         self.interactive = True           # default interactive mode
+        self.scan_threads = scan_threads
 
         if settings.config.api_secure:
             self.http_mode = 'https'


### PR DESCRIPTION
Use multi-threaded approach when fetching the size and features of the rbds defined to the config to cut down on start up time. This update sets an 8 thread default. We could in future, set the parallelism based on the number of disks in the config to scan to try and keep start up times around 1sec..just a thought