### PR TITLE
rbd-target-api: fix create gateway issue

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -207,6 +207,7 @@ def target(target_iqn=None):
                                    "for {} - {}".format(target_iqn,
                                                         target.error_msg)), 500
 
+        config.refresh()
         return jsonify(message="Target defined successfully"), 200
 
     else:


### PR DESCRIPTION
If create gateway is close behand creating target and without refreshing config, this action will be failed because of target_iqn is None.