### PR TITLE
rbd-target-api: get image's exclusive lock owner and break it

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -16,6 +16,8 @@ import platform
 from functools import wraps
 from rpm import labelCompare
 import rados
+import rbd
+from nose.tools import eq_ as eq
 
 import werkzeug
 from flask import Flask, jsonify, make_response, request
@@ -948,6 +950,17 @@ def clientlun(client_iqn):
         # this is a delete request
         if disk in lun_list:
             lun_list.remove(disk)
+
+            pool_name, image_name = disk.split('.')
+            with rados.Rados(conffile=settings.config.cephconf) as cluster:
+                with cluster.open_ioctx(pool_name) as ioctx:
+                    with rbd.Image(ioctx, image_name) as image:
+
+                        if len(image.list_lockers()):
+                            lock_owners = list(image.lock_get_owners())
+                            eq(1, len(lock_owners))
+                            eq(rbd.RBD_LOCK_MODE_EXCLUSIVE, lock_owners[0]['mode'])
+                            image.lock_break(rbd.RBD_LOCK_MODE_EXCLUSIVE, lock_owners[0]['owner'])
         else:
             return jsonify(message="disk not mapped to client"), 400
 


### PR DESCRIPTION
Once the client logged in and IOs are done, one of the iscsi
gateway nodes will hold the exclusive lock and be the lock
owner in tcmu-runner.

When we try rollback the snap shot of the image, it will become
readonly and failed even DELETE the LUN from the client host.

This patch will just get the lock owner and break it when doing
the LUN's DELETE opration.

Signed-off-by: Zhang Zhuoyu <zhangzhuoyu@cmss.chinamobile.com>
Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>