### PR TITLE
rbd-target-api: fix kernel release parser

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -1495,7 +1495,9 @@ def pre_reqs_errors():
     os_info = os.uname()
     this_arch = os_info[-1]
     this_kernel = os_info[2].replace(".{}".format(this_arch), '')
-    this_ver, this_rel = this_kernel.split('-')
+    kernel_dash_idx = this_kernel.find('-')
+    this_ver = this_kernel[:kernel_dash_idx]
+    this_rel = this_kernel[kernel_dash_idx+1:]
 
     # use labelCompare from the rpm module to handle the comparison
     if labelCompare(('1', this_ver, this_rel), ('1', k_vers, k_rel)) < 0:


### PR DESCRIPTION
This PR will fix the kernel release parser to support kernel release descriptions that contains dashes, preventing the following error:

```
...
File "/usr/lib/python2.7/site-packages/gwcli-2.5-py2.7.egg/EGG-INFO/scripts/rbd-target-api", line 1498, in pre_reqs_errors
    
ValueError: too many values to unpack
```

This error is reproducible on openSUSE Leap 42.2:

```
$ uname -r
4.4.74-18.20-default
```

Signed-off-by: Ricardo Marques <rimarques@suse.com>