### PR TITLE
Position correction of function gateways.remove(local_host)

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -936,8 +936,8 @@ def clientlun(client_iqn):
     logger.debug("this host is {}".format(local_gw))
     gateways = [key for key in config.config['gateways']
                 if isinstance(config.config['gateways'][key], dict)]
-    logger.debug("other gateways - {}".format(gateways))
     gateways.remove(local_gw)
+    logger.debug("other gateways - {}".format(gateways))
 
     disk = request.form.get('disk')
 


### PR DESCRIPTION
"gateways.remove(local_host)" should before "logger.debue('other gateways.....')"