### PR TITLE
Check for gw manage map errors

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -524,6 +524,10 @@ def _gateway(gateway_name=None):
 
                 logger.info("Syncing TPG to LUN mapping")
                 gateway.manage('map')
+                if gateway.error:
+                    gateway.manage('clearconfig')
+                    return jsonify(message="Failed to sync LUNs on gateway, "
+                                           "Err {}.".format(gateway.error_msg)), 500
 
                 logger.info("Syncing client configuration")
                 try:


### PR DESCRIPTION
The gw manage(map) call calls map_luns which could already fail due
to a LUN() creation error. It can now also fail due to invalid failover
type be set with this patch

https://github.com/ceph/ceph-iscsi-config/pull/69

commit 6738e54aab2db2345f3660c6403b2b1dbee81646
Author: Mike Christie <mchristi@redhat.com>
Date:   Mon Jul 23 16:45:30 2018 -0500

    Detect and handle invalid alua failover types

This patch has rbd-target-api check for gateway.error being set by a
caller which was not checking for errors. As far as I can tell the other
map callers are already checking for errors.

Signed-off-by: Mike Christie <mchristi@redhat.com>