### PR TITLE
Misc fixes for gwcli usability

### DIFF
--- a/gwcli.8
+++ b/gwcli.8
@@ -157,6 +157,11 @@ The create command will define the client IQN to all gateways within the configu
 The delete command will attempt to remove client IQN from all gateways within the configuration. The client must be logged out, for the delete command to be successful.
 .TP
 .nf
+\fB/iscsi-target/<iqn>/hosts/ auth nochap\fR
+.fi
+CHAP authentication can be reset to initiator based ACLs target wide for all setup ACLs using the \fBnochap\fR keyword. If there are multiple clients, CHAP must be enabled for all clients or disabled for all clients. gwcli does not support mixing CHAP clients with IQN ACL clients.
+.TP
+.nf
 \fB/iscsi-target/<iqn>/hosts/<client_iqn>/ auth chap=<user>/<pswd> | nochap\fR
 .fi
 CHAP authentication can be defined for the client with the \fBchap=\fR parameter. The username and password defined here must then be used within the client'd login credentials for this iscsi target. To remove chap authentication use the \fBnochap\fR keyword. If there are multiple clients, CHAP must be enabled for all clients or disabled for all clients. gwcli does not support mixing CHAP clients with IQN ACL clients.

--- a/gwcli.8
+++ b/gwcli.8
@@ -162,9 +162,9 @@ The delete command will attempt to remove client IQN from all gateways within th
 CHAP authentication can be reset to initiator based ACLs target wide for all setup ACLs using the \fBnochap\fR keyword. If there are multiple clients, CHAP must be enabled for all clients or disabled for all clients. gwcli does not support mixing CHAP clients with IQN ACL clients.
 .TP
 .nf
-\fB/iscsi-target/<iqn>/hosts/<client_iqn>/ auth chap=<user>/<pswd> | nochap\fR
+\fB/iscsi-target/<iqn>/hosts/<client_iqn>/ auth chap=<user>/<pswd>\fR
 .fi
-CHAP authentication can be defined for the client with the \fBchap=\fR parameter. The username and password defined here must then be used within the client'd login credentials for this iscsi target. To remove chap authentication use the \fBnochap\fR keyword. If there are multiple clients, CHAP must be enabled for all clients or disabled for all clients. gwcli does not support mixing CHAP clients with IQN ACL clients.
+CHAP authentication can be defined for the client with the \fBchap=\fR parameter. The username and password defined here must then be used within the clients login credentials for this iscsi target. If there are multiple clients, CHAP must be enabled for all clients or disabled for all clients. gwcli does not support mixing CHAP clients with IQN ACL clients.
 .TP
 .nf
 \fB/iscsi-target/<iqn>/hosts/<client_iqn>/ disk add | remove <disk_name>\fR

--- a/gwcli/client.py
+++ b/gwcli/client.py
@@ -209,7 +209,7 @@ class Clients(UIGroup):
         auth_stat_str = "None"
 
         for client in self.children:
-            if client.auth['chap'] == '':
+            if client.auth['chap'] == 'None':
                 chap_disabled = True
             else:
                 chap_enabled = True
@@ -261,7 +261,13 @@ class Client(UINode):
         # decode the password if necessary
         if 'chap' in self.auth:
             self.chap = CHAP(self.auth['chap'])
-            self.auth['chap'] = self.chap.chap_str
+
+            if self.chap.chap_str != '':
+                self.auth['chap'] = self.chap.chap_str
+            else:
+                self.auth['chap'] = "None"
+        else:
+            self.auth['chap'] = "None"
 
         self.refresh_luns()
 
@@ -297,7 +303,7 @@ class Client(UINode):
         status = False
 
         if 'chap' in self.auth:
-            if self.auth['chap']:
+            if self.auth['chap'] != 'None':
                 auth_text = "Auth: CHAP"
                 status = True
 
@@ -344,7 +350,11 @@ class Client(UINode):
 
         if api.response.status_code == 200:
             self.logger.debug("- client credentials updated")
-            self.auth['chap'] = chap
+            if chap != '':
+                self.auth['chap'] = chap
+            else:
+                self.auth['chap'] = "None"
+
             self.logger.info('ok')
 
         else:

--- a/gwcli/client.py
+++ b/gwcli/client.py
@@ -359,7 +359,7 @@ class Client(UINode):
         a string of the form <username>/<password>
 
         e.g.
-        auth chap=username/password | nochap
+        auth chap=username/password
 
         username ... the username is 8-64 character string. Each character
                      may either be an alphanumeric or use one of the following
@@ -371,18 +371,28 @@ class Client(UINode):
                      containing alphanumeric characters, plus the following
                      special characters @,_,-
 
-        WARNING: Using unsupported special characters may result in truncation,
-                 resulting in failed logins.
+        WARNING1: Using unsupported special characters may result in truncation,
+                  resulting in failed logins.
 
-
-        Specifying 'nochap' will remove chap authentication for the client
-        across all gateways. If there are multiple clients, CHAP must be
-        enabled for all clients or  disabled for all clients. gwcli does not
-        support mixing CHAP clients with IQN ACL clients.
+        WARNING2: If there are multiple clients, CHAP must be enabled for all
+        clients or  disabled for all clients. gwcli does not support mixing CHAP
+        clients with IQN ACL clients.
 
         """
 
         self.logger.debug("CMD: ../hosts/<client_iqn> auth *")
+
+        if not chap:
+            self.logger.error("To set authentication, specify "
+                              "chap=<user>/<password>")
+            return
+
+        if chap == 'nochap':
+            self.logger.error("CHAP must be disabled for all clients at the "
+                              "same time. Run the 'auth nochap' command from "
+                              "the hosts node within gwcli.")
+            return
+
         self.set_auth(chap)
 
     @staticmethod

--- a/gwcli/client.py
+++ b/gwcli/client.py
@@ -283,7 +283,9 @@ class Client(UINode):
 
 
         Specifying 'nochap' will remove chap authentication for the client
-        across all gateways.
+        across all gateways. If there are multiple clients, CHAP must be
+        enabled for all clients or  disabled for all clients. gwcli does not
+        support mixing CHAP clients with IQN ACL clients.
 
         """
 

--- a/gwcli/gateway.py
+++ b/gwcli/gateway.py
@@ -160,6 +160,18 @@ class ISCSIRoot(UIRoot):
         print(fmtd_config)
 
     def ui_command_export(self, mode='ansible'):
+        """
+        Print the configuration in a format that can be used by ceph-ansible or
+        as a backup.
+
+        The export command supports two modes:
+
+        ansible - The configuration will be printed in a format that can be
+                  used for the ceph-ansible iscsigws.yml.
+        copy - This prints the internal configuration. It can used for backup
+               or for support requests.
+        """
+
         valid_modes = ['ansible', 'copy']
 
         self.logger.debug("CMD: export mode={}".format(mode))

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -152,7 +152,7 @@ class Disks(UIGroup):
         Short format : create pool.image <size>
 
         e.g.
-        create pool=rbd image=testimage size=100g ring_buffer_size=16
+        create pool=rbd image=testimage size=100g max_data_area_mb=16
         create rbd.testimage 100g
 
         The syntax of each parameter is as follows;

--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -384,16 +384,16 @@ class Disks(UIGroup):
         An empty value for an attribute resets the lun attribute to its
         default.
 
-        image_id  : disk name (pool.image format)
+        image_id  : disk name (pool.image_id format)
         attribute : attribute to reconfigure. supported attributes:
             - max_data_area_mb : integer, size of kernel data ring buffer (MiB).
         value     : value of the attribute to reconfigure
 
         e.g.
         set max_data_area_mb
-          - reconfigure image=rbd.disk_1 attribute=max_data_area_mb value=128
+          - reconfigure image_id=rbd.disk_1 attribute=max_data_area_mb value=128
         reset max_data_area_mb to default
-          - reconfigure image=rbd.disk_1 attribute=max_data_area_mb value=
+          - reconfigure image_id=rbd.disk_1 attribute=max_data_area_mb value=
         """
         if image_id in self.disk_lookup:
             disk = self.disk_lookup[image_id]

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -603,11 +603,12 @@ def disk(image_id):
     :param pool: (str) the pool name the rbd image will be in
     :param count: (str) the number of images will be created
     :param owner: (str) the owner of the rbd image
-    :param ring_buffer_size: (str) size of the kernel ring buffer for this LUN
+    :param max_data_area_mb: (str) size of the kernel ring buffer that holds
+                              SCSI command's data.
     **RESTRICTED**
     Examples:
     curl --insecure --user admin:admin -d mode=create -d size=1g -d pool=rbd -d count=5 -X PUT https://192.168.122.69:5000/api/disk/rbd.new2_
-    curl --insecure --user admin:admin -d mode=create -d size=10g -d pool=rbd -dring_buffer_size=32 -X PUT https://192.168.122.69:5000/api/disk/rbd.new3_
+    curl --insecure --user admin:admin -d mode=create -d size=10g -d pool=rbd -dmax_data_area_mb=32 -X PUT https://192.168.122.69:5000/api/disk/rbd.new3_
     curl --insecure --user admin:admin -X GET https://192.168.122.69:5000/api/disk/rbd.new2_1
     curl --insecure --user admin:admin -X DELETE https://192.168.122.69:5000/api/disk/rbd.new2_1
     """


### PR DESCRIPTION
- Replace ring_buffer_size with max_data_area_mb in the disk create help command.

- Add a warning about all ACLs needing to be the same type in the auth help command.

- Document the export command.

- Replace the per client nochap command with a target wide one. For compat reasons the patch that removes the per client nochap support is in a separate patch and can be dropped if we feel we need to support it to avoid regressions with users that are using it in 2.7.