### PR TITLE
gwcli/storage: count is not a number when creating disks

### DIFF
--- a/gwcli/storage.py
+++ b/gwcli/storage.py
@@ -290,7 +290,7 @@ class Disks(UIGroup):
             self.logger.debug("Updating UI for the new disk(s)")
             for n in range(1, (int(count)+1), 1):
 
-                if count > 1:
+                if int(count) > 1:
                     disk_key = "{}.{}{}".format(pool, image, n)
                 else:
                     disk_key = "{}.{}".format(pool, image)


### PR DESCRIPTION
I got an erorr when creating a disk:

```
/disks> create rbd disk_q 10g 1 8
ok
GatewayAPIError: Unable to retrieve disk details for 'rbd.disk_q1' from the API
```

Surprisingly `count > 1` is true, so I printed `type(count)` and got `<type 'str'>`

```
self.logger.debug("=== type(count): {}".format(type(count)))
if count > 1:
        disk_key = "{}.{}{}".format(pool, image, n)
else:
        disk_key = "{}.{}".format(pool, image)
```

use `int(count) ` to fix it.