### PR TITLE
Fix default api port references

### DIFF
--- a/README
+++ b/README
@@ -42,7 +42,7 @@ add basic auth credentials to match the local api configuration in the RESTclien
 and use the client as follows;
 
 Add a Header content type for application/x-www-form-urlencoded
-METHOD: PUT        URL: https://192.168.122.69:5001/api/gateway/rh7-gw1
+METHOD: PUT        URL: https://192.168.122.69:5000/api/gateway/rh7-gw1
 select the urlencoded content type and the basic auth credentials
 add the required variables to the body section in the client ui
   eg. ip_address=192.168.122.69
@@ -54,7 +54,7 @@ If the UI is not your thing, curl probably is! Here's an example of using
 curl to create a gateway node.
 
 curl --insecure --user admin:admin -d "ip_address=192.168.122.104" \
-     -X PUT https://192.168.122.69:5001/api/gateway/rh7-gw2
+     -X PUT https://192.168.122.69:5000/api/gateway/rh7-gw2
 
 
 ## Installation

--- a/gwcli.8
+++ b/gwcli.8
@@ -50,7 +50,7 @@ By default the API service is not running with TLS, so for a more secure environ
 Once these files are inplace across the nodes, the rbd-target-api service can be started. Check that the API service is enabled and in the correct mode by looking at the output of 'systemctl status rbd-target-api'. You should see a message similar to
 .PP
 .RS 3
-\fB* Running on https://0.0.0.0:5001/\fR.
+\fB* Running on https://0.0.0.0:5000/\fR.
 .RE
 .PP
 The example gwcli output below shows a small two-gateway configuration, supporting 2 iSCSI clients


### PR DESCRIPTION
The default port is 5000 so update the docs.

Signed-off-by: Mike Christie <mchristi@redhat.com>