### PR TITLE
Move logs to dir

### DIFF
--- a/ceph-iscsi-cli.spec
+++ b/ceph-iscsi-cli.spec
@@ -83,6 +83,7 @@ install -m 0644 .%{_sysconfdir}/systemd/system/rbd-target-gw.service.d/dependenc
 %{_sysconfdir}/systemd/system/rbd-target-gw.service.d
 %{python2_sitelib}/*
 %{_mandir}/man8/gwcli.8.gz
+%attr(0770,root,root) %dir %{_localstatedir}/log/rbd-target-api
 
 %changelog
 

--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -2021,7 +2021,7 @@ if __name__ == '__main__':
     syslog_handler.setFormatter(syslog_format)
 
     # file target - more verbose logging for diagnostics
-    file_handler = RotatingFileHandler('/var/log/rbd-target-api.log',
+    file_handler = RotatingFileHandler('/var/log/rbd-target-api/rbd-target-api.log',
                                        maxBytes=5242880,
                                        backupCount=7)
     file_handler.setLevel(logging.DEBUG)

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'gwcli.py',
         'rbd-target-api.py'
     ],
+    data_files=[("/var/log/rbd-target-api", [])],
     cmdclass={
         "install_scripts": StripExtension
     }


### PR DESCRIPTION
The ceph selinux policy expects the logs to be in a dir under /var/log,
so this just moves our logs to /var/log/rbd-target-gw, so we do not have
to special case the ceph iscsi stuff in ceph-selinux.