### PR TITLE
fix disk resize failure

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -736,7 +736,9 @@ def disk(image_id):
                                                                      sfx)
 
             api_vars = {'pool': pool, 'size': size, 'owner': local_gw,
-                        'mode': mode, 'controls': request.form['controls']}
+                        'mode': mode}
+            if 'controls' in request.form:
+                api_vars['controls'] = request.form['controls']
 
             resp_text, resp_code = call_api(gateways, '_disk',
                                             image_name,


### PR DESCRIPTION
Only try to get and pass up controls if it was passed to us. This will
avoid an exception being thrown and generic:

Failed to resize : 400 BAD REQUEST

being returned for the disk resize command.