### PR TITLE
Use ceph-iscsi-config lun check

### DIFF
--- a/rbd-target-api.py
+++ b/rbd-target-api.py
@@ -835,10 +835,6 @@ def _disk(image_id):
             for k, v in controls.iteritems():
                 setattr(lun, k, v)
 
-            if mode == 'create' and len(config.config['disks']) >= 256:
-                logger.error("LUN alloc problem - too many LUNs")
-                return jsonify(message="LUN allocation failure: too many LUNs"), 500
-
             lun.allocate()
             if lun.error:
                 logger.error("LUN alloc problem - {}".format(lun.error_msg))


### PR DESCRIPTION
Drop out check and rely on the valid_disk check added in PR:
https://github.com/ceph/ceph-iscsi-config/pull/98

This fixes a bug where we try to add disk 256 and on the initial node
it works. But because the initial node does a lun.allocate that adds
the disk to the config, and the other nodes will hit the max lun check
which checks the config and fail to add the disk. It then leaves the
rbd image in the config.