### PR TITLE
Make generic info help a little nicer

### DIFF
--- a/gwcli/node.py
+++ b/gwcli/node.py
@@ -56,8 +56,7 @@ class UINode(UIGroup):
 
     def ui_command_info(self):
         """
-        Generic handler showing the attributes of the current object
-        :return: None
+        Show the attributes of the current object.
         """
 
         text = self.get_info()


### PR DESCRIPTION
The generic info help is a little user unfriendly because the return
None part looks like a bug. This patch drops that part and the generic
handler part of what gets displayed.